### PR TITLE
Update article for stopping systemd in Openshift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+.venv
+output

--- a/content/stopping-systemd-in-openshift.md
+++ b/content/stopping-systemd-in-openshift.md
@@ -25,9 +25,10 @@ how to overcome the limitation in Openshift by using container lifecycle hooks.
 
 **UPDATES**:
 
-- This is happening in Openshift but it will be fiex inin 4.10 (verified on
+- This is happening in Openshift but it will be fixed in 4.10 (verified on
   Openshift 4.10.0-ci-20220107).
 - Here is the change at cri-o that fix this situation: 
+  https://github.com/cri-o/cri-o/pull/5366
 
 # Defining the workload
 
@@ -202,7 +203,7 @@ STOPSIGNAL SIGINT
 CMD ["/demo-signal.sh"]
 ```
 
-The `demo-signal.sh` should have executing permission. The content is:
+The `demo-signal.sh` should have execute permission. The content is:
 
 ```sh
 #!/bin/bash

--- a/docs/archives.html
+++ b/docs/archives.html
@@ -94,7 +94,7 @@
           <dt>Mon 29 November 2021</dt>
 
         <dd>
-          <a href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html">Stopping systemd workloads in Openshift</a>
+          <a href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html">Stopping systemd workloads in OpenShift</a>
         </dd>
     </dl>
   </div>

--- a/docs/author/tinyeng.html
+++ b/docs/author/tinyeng.html
@@ -88,7 +88,7 @@
 
 <article>
   <header>
-    <h2><a href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift">Stopping systemd workloads in Openshift</a></h2>
+    <h2><a href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift">Stopping systemd workloads in OpenShift</a></h2>
     <p>
       Posted on Mon 29 November 2021 in <a href="https://avisiedo.github.io/docs/category/kubernetes.html">kubernetes</a>
 
@@ -97,11 +97,11 @@
   </header>
   <div>
       <h1>Overview</h1>
-<p>Are you using systemd workloads? then this article could be of your interest.
-Along this article we are going to see how the workloads based on systemd
-could be stopped gracefully on kubernetes.</p>
-<p>To show what we want to transmit into this article, we are going to do
-a …</p>
+<p>Are you using systemd workloads? Then this article could be of interest.
+In this article we are going to see how workloads based on systemd
+can be stopped gracefully on Openshift.</p>
+<p>We are going to do hands-on activities, using a simple systemd workload
+which runs an nginx service. We …</p>
         <br>
         <a class="btn"
            href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift">

--- a/docs/category/kubernetes.html
+++ b/docs/category/kubernetes.html
@@ -88,7 +88,7 @@
 
 <article>
   <header>
-    <h2><a href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift">Stopping systemd workloads in Openshift</a></h2>
+    <h2><a href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift">Stopping systemd workloads in OpenShift</a></h2>
     <p>
       Posted on Mon 29 November 2021 in <a href="https://avisiedo.github.io/docs/category/kubernetes.html">kubernetes</a>
 
@@ -97,11 +97,11 @@
   </header>
   <div>
       <h1>Overview</h1>
-<p>Are you using systemd workloads? then this article could be of your interest.
-Along this article we are going to see how the workloads based on systemd
-could be stopped gracefully on kubernetes.</p>
-<p>To show what we want to transmit into this article, we are going to do
-a …</p>
+<p>Are you using systemd workloads? Then this article could be of interest.
+In this article we are going to see how workloads based on systemd
+can be stopped gracefully on Openshift.</p>
+<p>We are going to do hands-on activities, using a simple systemd workload
+which runs an nginx service. We …</p>
         <br>
         <a class="btn"
            href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift">

--- a/docs/index.html
+++ b/docs/index.html
@@ -88,7 +88,7 @@
 
 <article>
   <header>
-    <h2><a href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift">Stopping systemd workloads in Openshift</a></h2>
+    <h2><a href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift">Stopping systemd workloads in OpenShift</a></h2>
     <p>
       Posted on Mon 29 November 2021 in <a href="https://avisiedo.github.io/docs/category/kubernetes.html">kubernetes</a>
 
@@ -97,11 +97,11 @@
   </header>
   <div>
       <h1>Overview</h1>
-<p>Are you using systemd workloads? then this article could be of your interest.
-Along this article we are going to see how the workloads based on systemd
-could be stopped gracefully on kubernetes.</p>
-<p>To show what we want to transmit into this article, we are going to do
-a …</p>
+<p>Are you using systemd workloads? Then this article could be of interest.
+In this article we are going to see how workloads based on systemd
+can be stopped gracefully on Openshift.</p>
+<p>We are going to do hands-on activities, using a simple systemd workload
+which runs an nginx service. We …</p>
         <br>
         <a class="btn"
            href="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html#stopping-systemd-workloads-in-openshift">

--- a/docs/stopping-systemd-workloads-in-openshift.html
+++ b/docs/stopping-systemd-workloads-in-openshift.html
@@ -125,9 +125,10 @@ how to overcome the limitation in Openshift by using container lifecycle hooks.<
 </blockquote>
 <p><strong>UPDATES</strong>:</p>
 <ul>
-<li>This is happening in Openshift but it will be fiex inin 4.10 (verified on
+<li>This is happening in Openshift but it will be fixed in 4.10 (verified on
   Openshift 4.10.0-ci-20220107).</li>
-<li>Here is the change at cri-o that fix this situation: </li>
+<li>Here is the change at cri-o that fix this situation: 
+  https://github.com/cri-o/cri-o/pull/5366</li>
 </ul>
 <h1>Defining the workload</h1>
 <p>We are going to use the following simple <code>Dockerfile.stopsignal-systemd</code> Dockerfile to build our workload.</p>
@@ -286,7 +287,7 @@ will use the following <code>Dockerfile.stopsignal-demo</code> Dockerfile:</p>
 <span class="k">CMD</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;/demo-signal.sh&quot;</span><span class="p">]</span>
 </code></pre></div>
 
-<p>The <code>demo-signal.sh</code> should have executing permission. The content is:</p>
+<p>The <code>demo-signal.sh</code> should have execute permission. The content is:</p>
 <div class="highlight"><pre><span></span><code><span class="ch">#!/bin/bash</span>
 
 <span class="k">function</span> trap_signal <span class="o">{</span>

--- a/docs/stopping-systemd-workloads-in-openshift.html
+++ b/docs/stopping-systemd-workloads-in-openshift.html
@@ -28,13 +28,13 @@
 
 
 <meta name="author" content="tinyeng" />
-<meta name="description" content="Overview Are you using systemd workloads? then this article could be of your interest. Along this article we are going to see how the workloads based on systemd could be stopped gracefully on kubernetes. To show what we want to transmit into this article, we are going to do a …" />
+<meta name="description" content="Overview Are you using systemd workloads? Then this article could be of interest. In this article we are going to see how workloads based on systemd can be stopped gracefully on Openshift. We are going to do hands-on activities, using a simple systemd workload which runs an nginx service. We …" />
 <meta name="keywords" content="">
 
 
 <meta property="og:site_name" content="Under the hood"/>
-<meta property="og:title" content="Stopping systemd workloads in Openshift"/>
-<meta property="og:description" content="Overview Are you using systemd workloads? then this article could be of your interest. Along this article we are going to see how the workloads based on systemd could be stopped gracefully on kubernetes. To show what we want to transmit into this article, we are going to do a …"/>
+<meta property="og:title" content="Stopping systemd workloads in OpenShift"/>
+<meta property="og:description" content="Overview Are you using systemd workloads? Then this article could be of interest. In this article we are going to see how workloads based on systemd can be stopped gracefully on Openshift. We are going to do hands-on activities, using a simple systemd workload which runs an nginx service. We …"/>
 <meta property="og:locale" content="en_US"/>
 <meta property="og:url" content="https://avisiedo.github.io/docs/stopping-systemd-workloads-in-openshift.html"/>
 <meta property="og:type" content="article"/>
@@ -44,7 +44,7 @@
 <meta property="article:section" content="kubernetes"/>
 <meta property="og:image" content="">
 
-  <title>Under the hood &ndash; Stopping systemd workloads in Openshift</title>
+  <title>Under the hood &ndash; Stopping systemd workloads in OpenShift</title>
 
 </head>
 <body class="light-theme">
@@ -95,7 +95,7 @@
 <article class="single">
   <header>
       
-    <h1 id="stopping-systemd-workloads-in-openshift">Stopping systemd workloads in Openshift</h1>
+    <h1 id="stopping-systemd-workloads-in-openshift">Stopping systemd workloads in OpenShift</h1>
     <p>
       Posted on Mon 29 November 2021 in <a href="https://avisiedo.github.io/docs/category/kubernetes.html">kubernetes</a>
 
@@ -105,49 +105,51 @@
 
   <div>
     <h1>Overview</h1>
-<p>Are you using systemd workloads? then this article could be of your interest.
-Along this article we are going to see how the workloads based on systemd
-could be stopped gracefully on kubernetes.</p>
-<p>To show what we want to transmit into this article, we are going to do
-a hands-on activities by using a simple systemd workload which run an nginx
-service; we will see the differences between using the workload in a container
-and using the workload in kubernetes. Finally we will see how to overcome the
-situation in kubernetes by using container lifecycle hooks.</p>
-<p>We are going to use <code>podman</code> and <code>openshift</code> for this article.</p>
+<p>Are you using systemd workloads? Then this article could be of interest.
+In this article we are going to see how workloads based on systemd
+can be stopped gracefully on Openshift.</p>
+<p>We are going to do hands-on activities, using a simple systemd workload
+which runs an nginx service. We will see the differences between using the
+workload in Podman and using the workload in Openshift. Finally we will see
+how to overcome the limitation in Openshift by using container lifecycle hooks.</p>
 <p><strong>Prerequisites</strong></p>
 <ul>
-<li><a href="https://podman.io/">Podman</a> is installed into your environment.</li>
-<li><a href="https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli">Openshift client</a> is installed into your environment.</li>
-<li>You have access to an Openshift cluster.</li>
+<li><a href="https://podman.io/">Podman</a> is installed in your environment.</li>
+<li><a href="https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli">OpenShift client</a> is installed into your environment.</li>
+<li>You have access to an OpenShift cluster.</li>
 </ul>
 <blockquote>
-<p>You can install a SNO by using:</p>
-<ul>
-<li><a href="https://github.com/karmab/kcli">kcli</a>.</li>
-<li><a href="https://github.com/code-ready/crc">Code Ready Containers</a>.</li>
-</ul>
+<p>You can install a single node OpenShift using
+<a href="https://github.com/karmab/kcli">kcli</a> or
+<a href="https://github.com/code-ready/crc">Code Ready Containers</a>.</p>
 </blockquote>
+<p><strong>UPDATES</strong>:</p>
+<ul>
+<li>This is happening in Openshift but it will be fiex inin 4.10 (verified on
+  Openshift 4.10.0-ci-20220107).</li>
+<li>Here is the change at cri-o that fix this situation: </li>
+</ul>
 <h1>Defining the workload</h1>
-<p>We are going to use the following simple Dockerfile to build our workload.</p>
-<div class="highlight"><pre><span></span><code><span class="k">FROM</span> <span class="s">quay.io/fedora/fedora:35</span>
-<span class="k">RUN</span> dnf -y install procps nginx <span class="se">\</span>
+<p>We are going to use the following simple <code>Dockerfile.stopsignal-systemd</code> Dockerfile to build our workload.</p>
+<div class="highlight"><pre><span></span><code><span class="k">FROM</span><span class="w"> </span><span class="s">quay.io/fedora/fedora:35</span>
+<span class="k">RUN</span><span class="w"> </span>dnf -y install procps nginx <span class="se">\</span>
     <span class="o">&amp;&amp;</span> dnf clean all <span class="se">\</span>
     <span class="o">&amp;&amp;</span> systemctl <span class="nb">enable</span> nginx
-<span class="k">EXPOSE</span><span class="s"> 80</span>
+<span class="k">EXPOSE</span><span class="w"> </span><span class="s">80</span>
 <span class="c"># https://docs.docker.com/engine/reference/builder/#stopsignal</span>
 <span class="c"># https://www.freedesktop.org/software/systemd/man/systemd.html#SIGRTMIN+3</span>
-<span class="k">STOPSIGNAL</span><span class="s"> SIGRTMIN+3</span>
-<span class="k">ENTRYPOINT</span> <span class="p">[</span><span class="s2">&quot;/sbin/init&quot;</span><span class="p">]</span>
+<span class="k">STOPSIGNAL</span><span class="w"> </span><span class="s">SIGRTMIN+3</span>
+<span class="k">ENTRYPOINT</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;/sbin/init&quot;</span><span class="p">]</span>
 </code></pre></div>
 
 <blockquote>
-<p>STOPSIGNAL instruction is not needed by podman as it detects that
-the signal to be sent should be SIGRTMIN+3 when <code>podman stop</code> is
-executed.</p>
+<p>The <code>STOPSIGNAL</code> instruction is not needed by podman as it detects that
+the signal to be sent by <code>podman stop</code> should be <code>SIGRTMIN+3</code>,
+because the container process is systemd.</p>
 </blockquote>
-<p>Now we build the container workload by:</p>
-<div class="highlight"><pre><span></span><code><span class="nb">export</span> <span class="nv">IMG</span><span class="o">=</span><span class="s2">&quot;quay.io/avisied0/demos:stopping-systemd&quot;</span>
-podman build -t <span class="s2">&quot;</span><span class="si">${</span><span class="nv">IMG</span><span class="si">}</span><span class="s2">&quot;</span> -f Dockerfile .
+<p>Now we build:</p>
+<div class="highlight"><pre><span></span><code><span class="nb">export</span> <span class="nv">IMG</span><span class="o">=</span><span class="s2">&quot;quay.io/avisied0/demos:stopsignal-systemd&quot;</span>
+podman build -t <span class="s2">&quot;</span><span class="si">${</span><span class="nv">IMG</span><span class="si">}</span><span class="s2">&quot;</span> -f Dockerfile.stopsignal-systemd .
 </code></pre></div>
 
 <h1>Runnning container with podman</h1>
@@ -185,25 +187,28 @@ Exiting container.
 [1]+  Done                    podman logs --follow &quot;<span class="cp">${</span><span class="n">CONTAINER_ID</span><span class="cp">}</span>&quot;
 </code></pre></div>
 
-<h1>What about Openshift?</h1>
-<p>Let's try now our workload into Openshift; you will need an Openshift cluster
-or a Single Node Openshift (you can get one by using
+<h1>What about OpenShift?</h1>
+<p>Let's try now our workload on OpenShift; you will need an OpenShift cluster
+or a single node OpenShift (you can get one by using
 <a href="https://github.com/karmab/kcli">kcli</a> or
 <a href="https://github.com/code-ready/crc">Code Ready Containers</a>).</p>
 <ul>
 <li>Push the image to your image registry:</li>
 </ul>
-<div class="highlight"><pre><span></span><code>podman push <span class="s2">&quot;</span><span class="si">${</span><span class="nv">IMG</span><span class="si">}</span><span class="s2">&quot;</span>
+<div class="highlight"><pre><span></span><code><span class="c1"># Previously IMG was defined as below:</span>
+<span class="c1"># export IMG=&quot;quay.io/avisied0/demos:stopsignal-systemd&quot;</span>
+podman push <span class="s2">&quot;</span><span class="si">${</span><span class="nv">IMG</span><span class="si">}</span><span class="s2">&quot;</span>
 </code></pre></div>
 
 <blockquote>
-<p>Check that the repository is public for pulling the image.</p>
+<p>Ensure the repository is public so that the cluster can pull
+the image.</p>
 </blockquote>
 <ul>
-<li>Access your cluster as a cluster admin and create a new project:.</li>
+<li>Access your cluster as a cluster admin and create a new project:</li>
 </ul>
 <div class="highlight"><pre><span></span><code>oc login -u kubeadmin https://api.crc.testing:6443
-oc new-project stopping-systemd
+oc new-project stopsignal
 </code></pre></div>
 
 <ul>
@@ -217,170 +222,181 @@ oc adm policy add-role-to-user edit -z runasanyuid --as system:admin
 </code></pre></div>
 
 <ul>
-<li>Create the pod.yaml file as the below:</li>
+<li>Create the Pod from the following <code>pod-stopsignal-systemd.yaml</code> file:</li>
 </ul>
-<div class="highlight"><pre><span></span><code><span class="nt">apiVersion</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">v1</span>
-<span class="nt">kind</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">Pod</span>
-<span class="nt">metadata</span><span class="p">:</span>
-  <span class="nt">name</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">systemd-nginx</span>
-  <span class="nt">labels</span><span class="p">:</span>
-    <span class="nt">app</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">nginx</span>
-<span class="nt">spec</span><span class="p">:</span>
-  <span class="nt">serviceAccount</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">runasanyuid</span>
-  <span class="nt">containers</span><span class="p">:</span>
-  <span class="p p-Indicator">-</span> <span class="nt">name</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">nginx</span>
-    <span class="nt">image</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">quay.io/avisied0/demos:stopping-systemd</span>
-    <span class="nt">imagePullPolicy</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">Always</span>
-    <span class="nt">command</span><span class="p">:</span> <span class="p p-Indicator">[</span><span class="s">&quot;/sbin/init&quot;</span><span class="p p-Indicator">]</span>
-    <span class="nt">tty</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">true</span>
-    <span class="nt">privileged</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">false</span>
+<div class="highlight"><pre><span></span><code><span class="nt">apiVersion</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">v1</span><span class="w"></span>
+<span class="nt">kind</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">Pod</span><span class="w"></span>
+<span class="nt">metadata</span><span class="p">:</span><span class="w"></span>
+<span class="w">  </span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">stopsignal-systemd</span><span class="w"></span>
+<span class="w">  </span><span class="nt">labels</span><span class="p">:</span><span class="w"></span>
+<span class="w">    </span><span class="nt">app</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">nginx</span><span class="w"></span>
+<span class="nt">spec</span><span class="p">:</span><span class="w"></span>
+<span class="w">  </span><span class="nt">serviceAccountName</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">runasanyuid</span><span class="w"></span>
+<span class="w">  </span><span class="nt">automountServiceAccountToken</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">false</span><span class="w"></span>
+<span class="w">  </span><span class="nt">containers</span><span class="p">:</span><span class="w"></span>
+<span class="w">  </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">nginx</span><span class="w"></span>
+<span class="w">    </span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">quay.io/avisied0/demos:stopsignal-systemd</span><span class="w"></span>
+<span class="w">    </span><span class="nt">imagePullPolicy</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">Always</span><span class="w"></span>
+<span class="w">    </span><span class="nt">command</span><span class="p">:</span><span class="w"> </span><span class="p p-Indicator">[</span><span class="s">&quot;/sbin/init&quot;</span><span class="p p-Indicator">]</span><span class="w"></span>
+<span class="w">    </span><span class="nt">tty</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">true</span><span class="w"></span>
+<span class="w">    </span><span class="nt">privileged</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">false</span><span class="w"></span>
 </code></pre></div>
 
 <ul>
-<li>Create the workload into our cluster by using the above serviceaccount:</li>
+<li>Create the workload using the new serviceaccount:</li>
 </ul>
-<div class="highlight"><pre><span></span><code>oc create -f pod.yaml --as<span class="o">=</span>runasanyuid
+<div class="highlight"><pre><span></span><code>oc create -f pod-stopsignal-systemd.yaml --as system:serviceaccount:stopsignal:runasanyuid
 oc get all
 </code></pre></div>
 
 <ul>
 <li>Print out and follow the logs in the background.</li>
 </ul>
-<div class="highlight"><pre><span></span><code>oc logs pod/systemd-nginx -f <span class="p">&amp;</span>
+<div class="highlight"><pre><span></span><code>oc logs pod/stopsignal-systemd -f --as system:serviceaccount:stopsignal:runasanyuid <span class="p">&amp;</span>
 </code></pre></div>
 
 <ul>
 <li>Try to stop the workload.</li>
 </ul>
-<div class="highlight"><pre><span></span><code>oc delete -f pod.yaml
+<div class="highlight"><pre><span></span><code>oc delete -f pod-stopsignal-systemd.yaml --as system:serviceaccount:stopsignal:runasanyuid
 </code></pre></div>
 
-<p>We get something like the below into the logs, but systemd and the pod is
-not stopped after a while:</p>
+<p>We get something like the below in the log output, but systemd and
+the pod are still running:</p>
 <div class="highlight"><pre><span></span><code>pod &quot;systemd-nginx&quot; deleted
 systemd-nginx login: systemd v249.7-2.fc35 running in system mode (+PAM +AUDIT +SELINUX -APPARMOR +IMA +SMACK +SECCOMP +GCRYPT +GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 +PWQUALITY +P11KIT +QRENCODE +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified)
 Detected virtualization podman.
 Detected architecture x86-64.
 </code></pre></div>
 
-<p>We can see that systemd does not begin the stop sequence as in the case of the
-container; this is because kubernetes does not passthrough the STOPSIGNAL
-instruction that is found into the Dockerfile. For fix this situation we will
-use the <a href="https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/">container lifecycle hooks</a>,
-and we will explicitely send the SIGRTMIN+3 to the PID 1 (systemd).</p>
+<p>We can see that systemd does not begin the stop sequence as was the
+case with podman.  This is because Openshift did not translate the
+<code>STOPSIGNAL</code> instruction specified in the Dockerfile (this will be fixed
+at Openshift 4.10). To work around this situation we will
+use <a href="https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/">container lifecycle hooks</a>,
+to explicitly send <code>SIGRTMIN+3</code> to PID 1 (systemd).</p>
 <h1>Trying more isolated</h1>
-<p>Let's try if this happens only for SIGRTMIN+3 or for any signal used for
-STOPSIGNAL instruction. To investigate that, we will use the following
-Dockerfile file:</p>
-<div class="highlight"><pre><span></span><code><span class="k">FROM</span> <span class="s">quay.io/fedora/fedora:35</span>
-<span class="k">COPY</span> demo-signal.sh /demo-signal.sh
-<span class="k">STOPSIGNAL</span><span class="s"> SIGINT</span>
-<span class="k">ENTRYPOINT</span> <span class="p">[</span><span class="s2">&quot;/demo-signal.sh&quot;</span><span class="p">]</span>
+<p>Let's see if this happens only for <code>SIGRTMIN+3</code> or for any signal
+specified via the <code>STOPSIGNAL</code> instruction. To investigate that, we
+will use the following <code>Dockerfile.stopsignal-demo</code> Dockerfile:</p>
+<div class="highlight"><pre><span></span><code><span class="k">FROM</span><span class="w"> </span><span class="s">quay.io/fedora/fedora:35</span>
+<span class="k">COPY</span><span class="w"> </span>demo-signal.sh /demo-signal.sh
+<span class="k">RUN</span><span class="w"> </span>chmod a+x /demo-signal.sh
+<span class="k">STOPSIGNAL</span><span class="w"> </span><span class="s">SIGINT</span>
+<span class="k">CMD</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;/demo-signal.sh&quot;</span><span class="p">]</span>
 </code></pre></div>
 
-<p>The <code>demo-signal.sh</code> should has execution permissions and the content is the
-below:</p>
+<p>The <code>demo-signal.sh</code> should have executing permission. The content is:</p>
 <div class="highlight"><pre><span></span><code><span class="ch">#!/bin/bash</span>
 
-<span class="k">function</span> trap_sigint <span class="o">{</span> <span class="nb">echo</span> <span class="s2">&quot;Exiting by SIGINT&quot;</span><span class="p">;</span>  <span class="nb">exit</span> <span class="m">0</span><span class="p">;</span> <span class="o">}</span>
-<span class="k">function</span> trap_sigterm <span class="o">{</span> <span class="nb">echo</span> <span class="s2">&quot;Exiting by SIGTERM&quot;</span><span class="p">;</span> <span class="nb">exit</span> <span class="m">0</span><span class="p">;</span> <span class="o">}</span>
-<span class="k">function</span> trap_sigusr1 <span class="o">{</span> <span class="nb">echo</span> <span class="s2">&quot;Exiting by SIGUSR1&quot;</span><span class="p">;</span> <span class="nb">exit</span> <span class="m">0</span><span class="p">;</span> <span class="o">}</span>
-<span class="k">function</span> trap_sigrtmin3 <span class="o">{</span> <span class="nb">echo</span> <span class="s2">&quot;Exiting by SIGRTMIN+3&quot;</span><span class="p">;</span> <span class="nb">exit</span> <span class="m">0</span><span class="p">;</span> <span class="o">}</span>
+<span class="k">function</span> trap_signal <span class="o">{</span>
+  <span class="nb">local</span> <span class="nv">signal</span><span class="o">=</span><span class="s2">&quot;</span><span class="nv">$1</span><span class="s2">&quot;</span>
+  <span class="nb">echo</span> -e <span class="s2">&quot;\nExiting by </span><span class="si">${</span><span class="nv">signal</span><span class="si">}</span><span class="s2">&quot;</span> &gt;<span class="p">&amp;</span><span class="m">2</span>
+  <span class="nb">exit</span> <span class="m">0</span>
+<span class="o">}</span>
 
-<span class="nb">trap</span> trap_sigint SIGINT
-<span class="nb">trap</span> trap_sigterm SIGTERM
-<span class="nb">trap</span> trap_sigusr1 SIGUSR1
-<span class="nb">trap</span> trap_sigrtmin3 <span class="s2">&quot;SIGRTMIN+3&quot;</span>
+<span class="k">for</span> signal <span class="k">in</span> SIGINT SIGTERM SIGUSR1 <span class="s2">&quot;SIGRTMIN+3&quot;</span>
+<span class="k">do</span>
+  <span class="nb">trap</span> <span class="s2">&quot;trap_signal &#39;</span><span class="si">${</span><span class="nv">signal</span><span class="si">}</span><span class="s2">&#39;&quot;</span> <span class="s2">&quot;</span><span class="si">${</span><span class="nv">signal</span><span class="si">}</span><span class="s2">&quot;</span>
+<span class="k">done</span>
 
-<span class="k">while</span> true<span class="p">;</span> <span class="k">do</span> sleep <span class="m">1</span><span class="p">;</span> <span class="k">done</span>
+<span class="k">while</span> true<span class="p">;</span> <span class="k">do</span>
+    <span class="nb">echo</span> -n <span class="s2">&quot;.&quot;</span>
+    sleep <span class="m">1</span>
+<span class="k">done</span>
 </code></pre></div>
 
-<p>Finally we define a workload with the pod.yaml file below:</p>
-<div class="highlight"><pre><span></span><code><span class="nt">apiVersion</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">v1</span>
-<span class="nt">kind</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">Pod</span>
-<span class="nt">metadata</span><span class="p">:</span>
-  <span class="nt">name</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">demo-signals</span>
-  <span class="nt">labels</span><span class="p">:</span>
-    <span class="nt">app</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">signals</span>
-<span class="nt">spec</span><span class="p">:</span>
-  <span class="nt">containers</span><span class="p">:</span>
-  <span class="p p-Indicator">-</span> <span class="nt">name</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">main</span>
-    <span class="nt">image</span><span class="p">:</span> <span class="l l-Scalar l-Scalar-Plain">quay.io/avisied0/demos:signals</span>
-    <span class="nt">command</span><span class="p">:</span> <span class="p p-Indicator">[</span><span class="s">&quot;/demo-signal.sh&quot;</span><span class="p p-Indicator">]</span>
+<blockquote>
+<p>Update: Script updated based on PR at: https://github.com/avisiedo/freeipa-kustomize/blob/idmocp-331-stopping-with-kind-and-podman/incubator/013-signalstop/demo-signal.sh</p>
+</blockquote>
+<p>Finally we define a workload with the following <code>pod-stopsignal-demo.yaml</code>:</p>
+<div class="highlight"><pre><span></span><code><span class="nt">apiVersion</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">v1</span><span class="w"></span>
+<span class="nt">kind</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">Pod</span><span class="w"></span>
+<span class="nt">metadata</span><span class="p">:</span><span class="w"></span>
+<span class="w">  </span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">stopsignal-demo</span><span class="w"></span>
+<span class="w">  </span><span class="nt">labels</span><span class="p">:</span><span class="w"></span>
+<span class="w">    </span><span class="nt">app</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">stopsignals</span><span class="w"></span>
+<span class="nt">spec</span><span class="p">:</span><span class="w"></span>
+<span class="w">  </span><span class="nt">automountServiceAccountToken</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">false</span><span class="w"></span>
+<span class="w">  </span><span class="nt">containers</span><span class="p">:</span><span class="w"></span>
+<span class="w">  </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">main</span><span class="w"></span>
+<span class="w">    </span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">quay.io/avisied0/demos:stopsignal-demo</span><span class="w"></span>
+<span class="w">    </span><span class="nt">imagePullPolicy</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">Always</span><span class="w"></span>
+<span class="w">    </span><span class="nt">command</span><span class="p">:</span><span class="w"></span>
+<span class="w">    </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">/demo-signal.sh</span><span class="w"></span>
+<span class="w">    </span><span class="nt">tty</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">true</span><span class="w"></span>
+<span class="w">    </span><span class="nt">privileged</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">false</span><span class="w"></span>
+</code></pre></div>
+
+<p>Build the image and push:</p>
+<div class="highlight"><pre><span></span><code><span class="nb">export</span> <span class="nv">IMG</span><span class="o">=</span><span class="s2">&quot;quay.io/avisied0/demos:stopsignal-demo&quot;</span>
+podman build -t <span class="s2">&quot;</span><span class="si">${</span><span class="nv">IMG</span><span class="si">}</span><span class="s2">&quot;</span> -f Dockerfile.stopsignal-demo .
+podman push <span class="s2">&quot;</span><span class="si">${</span><span class="nv">IMG</span><span class="si">}</span><span class="s2">&quot;</span>
 </code></pre></div>
 
 <p>And we try the scenario by:</p>
-<div class="highlight"><pre><span></span><code>podman build -t quay.io/avisied0/demos:signals -f Dockerfile .
-podman push quay.io/avisied0/demos:signals
-oc create -f pod.yaml
-oc logs pod/demo-signals -f <span class="p">&amp;</span>
-oc delete -f pod.yaml
+<div class="highlight"><pre><span></span><code>oc create -f pod-stopsignal-demo.yaml --as system:serviceaccount:stopsignal:runasanyuid
+oc logs pod/stopsignal-demo -f --as system:serviceaccount:stopsignal:runasanyuid <span class="p">&amp;</span>
+oc delete -f pod-stopsignal-demo.yaml --as system:serviceaccount:stopsignal:runasanyuid
 </code></pre></div>
 
 <p>Getting the output below:</p>
-<div class="highlight"><pre><span></span><code><span class="n">pod</span> <span class="s2">&quot;demo-signals&quot;</span> <span class="n">deleted</span>
-<span class="n">Exiting</span> <span class="n">by</span> <span class="n">SIGTERM</span>
+<div class="highlight"><pre><span></span><code><span class="n">pod</span><span class="w"> </span><span class="s2">&quot;stopsignal-demo&quot;</span><span class="w"> </span><span class="n">deleted</span><span class="w"></span>
+<span class="o">............</span><span class="w"></span>
+<span class="n">Exiting</span><span class="w"> </span><span class="n">by</span><span class="w"> </span><span class="n">SIGINT</span><span class="w"></span>
 </code></pre></div>
 
-<p>So when the pod is deleted, SIGTERM signal is send to the containers that
-belong to the Pod whatever is the STOPSIGNAL instruction that is defined into
-the container image.</p>
+<p>When the <code>SIGINT</code> is specified into the STOPSIGNAL instruction in the Dockerfile
+Openshift is sending SIGINT signal to the pod when we delete the resource.</p>
 <blockquote>
-<p>It was tested using numeric numbers for STOPSIGNAL instruction instead of
-the name of the signal, and the result did not change.</p>
+<p>When the <code>STOPSIGNAL 37</code> (<code>RTMIN+3</code>) is specified as a numeric value, Openshift
+is sending SIGTERM instead of the expected <code>SIGRTMIN+3</code> indicated into the
+Dockerfile file.</p>
+<p>It was tested in Openshift 4.10 ci build on Wed Jan 5, 2022 and it worked
+as expected, by sending the <code>SIGRTMIN+3</code> to the container workload.</p>
 </blockquote>
-<h1>Solution by using container lifecycle hooks</h1>
+<h1>Solution: container lifecycle hooks</h1>
 <ul>
-<li>Update the <code>pod.yaml</code> file with the content below:</li>
+<li>Create <code>pod-stopsignal-lifecycle.yaml</code> with the content below:</li>
 </ul>
-<div class="highlight"><pre><span></span><code>apiVersion: v1
-kind: Pod
-metadata:
-  name: systemd-nginx
-  labels:
-    app: nginx
-spec:
-  serviceAccount: runasanyuid
-  containers:
-  - name: nginx
-    image: quay.io/avisied0/demos:stopping-systemd
-    imagePullPolicy: Always
-    command: <span class="o">[</span><span class="s2">&quot;/sbin/init&quot;</span><span class="o">]</span>
-    tty: <span class="nb">true</span>
-    privileged: <span class="nb">false</span>
-    lifecycle:  <span class="c1"># (1)</span>
-      preStop:  <span class="c1"># (2)</span>
-        exec:   <span class="c1"># (3)</span>
-          command: <span class="o">[</span><span class="s2">&quot;kill&quot;</span>, <span class="s2">&quot;-RTMIN+3&quot;</span>, <span class="s2">&quot;1&quot;</span><span class="o">]</span>   <span class="c1"># (4)</span>
+<div class="highlight"><pre><span></span><code><span class="nt">apiVersion</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">v1</span><span class="w"></span>
+<span class="nt">kind</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">Pod</span><span class="w"></span>
+<span class="nt">metadata</span><span class="p">:</span><span class="w"></span>
+<span class="w">  </span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">stopsignal-lifecycle</span><span class="w"></span>
+<span class="w">  </span><span class="nt">labels</span><span class="p">:</span><span class="w"></span>
+<span class="w">    </span><span class="nt">app</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">nginx</span><span class="w"></span>
+<span class="nt">spec</span><span class="p">:</span><span class="w"></span>
+<span class="w">  </span><span class="nt">serviceAccount</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">runasanyuid</span><span class="w"></span>
+<span class="w">  </span><span class="nt">containers</span><span class="p">:</span><span class="w"></span>
+<span class="w">  </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">nginx</span><span class="w"></span>
+<span class="w">    </span><span class="nt">image</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">quay.io/avisied0/demos:stopping-systemd</span><span class="w"></span>
+<span class="w">    </span><span class="nt">imagePullPolicy</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">Always</span><span class="w"></span>
+<span class="w">    </span><span class="nt">command</span><span class="p">:</span><span class="w"> </span><span class="p p-Indicator">[</span><span class="s">&quot;/sbin/init&quot;</span><span class="p p-Indicator">]</span><span class="w"></span>
+<span class="w">    </span><span class="nt">tty</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">true</span><span class="w"></span>
+<span class="w">    </span><span class="nt">privileged</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">false</span><span class="w"></span>
+<span class="w">    </span><span class="nt">lifecycle</span><span class="p">:</span><span class="w">  </span><span class="c1"># (1)</span><span class="w"></span>
+<span class="w">      </span><span class="nt">preStop</span><span class="p">:</span><span class="w">  </span><span class="c1"># (2)</span><span class="w"></span>
+<span class="w">        </span><span class="nt">exec</span><span class="p">:</span><span class="w">   </span><span class="c1"># (3)</span><span class="w"></span>
+<span class="w">          </span><span class="nt">command</span><span class="p">:</span><span class="w"> </span><span class="p p-Indicator">[</span><span class="s">&quot;kill&quot;</span><span class="p p-Indicator">,</span><span class="w"> </span><span class="s">&quot;-RTMIN+3&quot;</span><span class="p p-Indicator">,</span><span class="w"> </span><span class="s">&quot;1&quot;</span><span class="p p-Indicator">]</span><span class="w">   </span><span class="c1"># (4)</span><span class="w"></span>
 </code></pre></div>
 
 <ul>
 <li>(1) The lifecycle hooks for that container.</li>
-<li>(2) Indicate that will be called before stopping the container.</li>
-<li>(3) It will be an exec command.</li>
+<li>(2) A <code>preStop</code> hook is called before stopping the container.</li>
+<li>(3) It will be an <code>exec</code> command.</li>
 <li>
-<p>(4) The command to be executed; the command should exist inside the container.</p>
+<p>(4) The command to be executed; the executable must exist in the container.</p>
 </li>
 <li>
-<p>Create the pod again:</p>
+<p>And we try again by:</p>
 </li>
 </ul>
-<div class="highlight"><pre><span></span><code>oc create -f pod.yaml --as<span class="o">=</span>runasanyuid
+<div class="highlight"><pre><span></span><code>oc create -f pod-stopsignal-lifecycle.yaml --as<span class="o">=</span>system:serviceaccount:stopsignal:runasanyuid
+oc logs pod/stopsignal-lifecycle -f --as<span class="o">=</span>system:serviceaccount:stopsignal:runasanyuid <span class="p">&amp;</span>
+oc delete -f pod-stopsignal-lifecycle.yaml --as<span class="o">=</span>system:serviceaccount:stopsignal:runasanyuid
 </code></pre></div>
 
-<ul>
-<li>Print out and follow the logs in the background:</li>
-</ul>
-<div class="highlight"><pre><span></span><code>oc logs pod/systemd-nginx -f <span class="p">&amp;</span>
-</code></pre></div>
-
-<ul>
-<li>Now we delete the pod:</li>
-</ul>
-<div class="highlight"><pre><span></span><code>oc delete -f pod.yaml
-</code></pre></div>
-
-<p>And finally what we get immeditalty is the below:</p>
+<p>And the log output immediately shows the below:</p>
 <div class="highlight"><pre><span></span><code><span class="n">pod</span><span class="w"> </span><span class="ss">&quot;systemd-nginx&quot;</span><span class="w"> </span><span class="n">deleted</span><span class="w"></span>
 <span class="n">systemd</span><span class="o">-</span><span class="n">nginx</span><span class="w"> </span><span class="nl">login</span><span class="p">:</span><span class="w"> </span><span class="o">[</span><span class="n">  OK  </span><span class="o">]</span><span class="w"> </span><span class="n">Removed</span><span class="w"> </span><span class="n">slice</span><span class="w"> </span><span class="n">Slice</span><span class="w"> </span><span class="o">/</span><span class="k">system</span><span class="o">/</span><span class="n">getty</span><span class="p">.</span><span class="w"></span>
 <span class="o">[</span><span class="n">  OK  </span><span class="o">]</span><span class="w"> </span><span class="n">Removed</span><span class="w"> </span><span class="n">slice</span><span class="w"> </span><span class="n">Slice</span><span class="w"> </span><span class="o">/</span><span class="k">system</span><span class="o">/</span><span class="n">modprobe</span><span class="p">.</span><span class="w"></span>
@@ -463,13 +479,13 @@ spec:
 <h1>Wrap up</h1>
 <p>In this article we have seen that:</p>
 <ul>
-<li>systemd workloads use SIGRTMIN+3 for stopping the workload gracefully.</li>
-<li>Kubernetes does not passthrough the STOPSIGNAL instruction from Dockerfile
-  to the container definition.</li>
-<li>We can use a container lifecycle hook for the ones that could require it to
-  interact with the workload before stop the container, and for this specific
-  scenario, to send the SIGRTMIN+3 signal to PID 1 (systemd). This
-  requires the <code>kill</code> binary inside the container for sending the signal.</li>
+<li>systemd workloads need <code>SIGRTMIN+3</code> for stopping the workload gracefully.</li>
+<li>OpenShift does not send the signal specified in the container
+  image (via the <code>STOPSIGNAL</code> instruction). It does starting in Openshift 4.10.</li>
+<li>We can use a container lifecycle hook to
+  interact with the workload when stopping the container until the fix is
+  available. For this scenario, we can use the <code>kill</code> binary (which must exist in the
+  container) to send <code>SIGRTMIN+3</code> to PID 1 (systemd).</li>
 </ul>
 <h1>References</h1>
 <ul>
@@ -478,6 +494,7 @@ spec:
 <li><a href="https://docs.docker.com/engine/reference/builder/#stopsignal">Dockerfile - STOPSIGNAL</a>.</li>
 <li><a href="https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/">Container Lifecycle Hooks</a>.</li>
 <li><a href="https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/">Attach Handlers to Container Lifecycle Events</a>.</li>
+<li><strong>UPDATE</strong>: <a href="https://bugzilla.redhat.com/show_bug.cgi?id=2000877">BZ 2000877</a>.</li>
 </ul>
   </div>
   <div class="tag-cloud">


### PR DESCRIPTION
- The situation was tried in Openshift 4.10 and it fixes
  the situation.
- Update the script which is used for testing the signals.
- Some mistakes detected during updating the article, such as
  imagePullPolicy attribute that was not specified, and the
  validation for SIGINT which indeed is working in Openshift.
- Update .gitignore for .venv and output directories.